### PR TITLE
add options to heroku addons

### DIFF
--- a/lib/github_heroku_deployer.rb
+++ b/lib/github_heroku_deployer.rb
@@ -73,10 +73,10 @@ module GithubHerokuDeployer
       Heroku.new(options).config_set(values)
     end
 
-    def heroku_addon_add(addon, options={})
+    def heroku_addon_add(addon, options={}, addon_options={})
       options = configuration.merge(options)
       validate_options(options)
-      Heroku.new(options).addon_add(addon)
+      Heroku.new(options).addon_add(addon, addon_options)
     end
 
     def heroku_post_ps_scale(process, quantity, options={})

--- a/lib/github_heroku_deployer/heroku.rb
+++ b/lib/github_heroku_deployer/heroku.rb
@@ -51,8 +51,8 @@ module GithubHerokuDeployer
       heroku.put_config_vars(@heroku_app_name, config_vars)
     end
 
-    def addon_add(addon, options={})
-      heroku.post_addon(@heroku_app_name, addon, options)
+    def addon_add(addon, addon_options={})
+      heroku.post_addon(@heroku_app_name, addon, addon_options)
     end
 
     def addon_remove(addon)


### PR DESCRIPTION
Extends Heroku addons to optionally pass addon options - necessary for implementing post deploy hook urls, etc