### PR TITLE
unset GIT_WORK_TREE before clone

### DIFF
--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -53,7 +53,7 @@ module GithubHerokuDeployer
     def clone
       wrapper = ssh_wrapper
       @logger.info "cloning #{@github_repo} to #{folder}"
-      run "env #{wrapper.git_ssh} git clone #{@github_repo} #{folder}"
+      run "unset GIT_WORK_TREE; env #{wrapper.git_ssh} git clone #{@github_repo} #{folder}"
     ensure
       wrapper.unlink
     end


### PR DESCRIPTION
Fixes bug where cloning in parallel with Heroku causes git work tree to crash out.