### PR TITLE
Update to platform api

### DIFF
--- a/github_heroku_deployer.gemspec
+++ b/github_heroku_deployer.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "heroku-api", "~> 0.3.5"
   gem.add_dependency "platform-api", "~> 2.1.0"
   gem.add_dependency "git", "~> 1.2.5"
   gem.add_dependency "git-ssh-wrapper", "~> 0.1.0"

--- a/github_heroku_deployer.gemspec
+++ b/github_heroku_deployer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "heroku-api", "~> 0.3.5"
-  gem.add_dependency "platform-api" "~> 2.1.0"
+  gem.add_dependency "platform-api", "~> 2.1.0"
   gem.add_dependency "git", "~> 1.2.5"
   gem.add_dependency "git-ssh-wrapper", "~> 0.1.0"
 

--- a/github_heroku_deployer.gemspec
+++ b/github_heroku_deployer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "heroku-api", "~> 0.3.5"
-  gem.add_dependency "platform-api", "~> 0.2"
+  gem.add_dependency "platform-api" "~> 2.1.0"
   gem.add_dependency "git", "~> 1.2.5"
   gem.add_dependency "git-ssh-wrapper", "~> 0.1.0"
 

--- a/github_heroku_deployer.gemspec
+++ b/github_heroku_deployer.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "git", "~> 1.2.5"
   gem.add_dependency "git-ssh-wrapper", "~> 0.1.0"
 
-  gem.add_development_dependency "simplecov", "~> 0.7.1"
+  gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "rspec", "~> 2.11.0"
   gem.add_development_dependency "guard-rspec", "~> 2.1.0"
+  gem.add_development_dependency "guard", "2.12.6"
   gem.add_development_dependency "rb-fsevent", "~> 0.9.2"
 end

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -19,7 +19,7 @@ module GithubHerokuDeployer
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
       @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{@branch}"
-      run "cd #{repo.dir}; git checkout #{@branch}; env #{wrapper.git_ssh} git push -f #{remote} #{@branch}"
+      run "cd #{repo.dir}; git checkout #{@branch}; env #{wrapper.git_ssh} git push -f #{remote} #{@branch}:master"
     ensure
       wrapper.unlink
     end

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -12,17 +12,17 @@ module GithubHerokuDeployer
       @repo_dir = options[:repo_dir]
     end
 
-    def push_app_to_heroku(remote="heroku", branch="master", &block)
+    def push_app_to_heroku(remote="heroku", branch="update-gemfilelock", &block)
       wrapper = ssh_wrapper
       run "cd #{repo.dir}; git remote rm #{remote}" if repo.remote(remote).url
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
       @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{branch}"
-      # modified this to push non custom branch for local testing
-      run "cd #{repo.dir}; env #{wrapper.git_ssh} git checkout #{branch}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
+      run "cd #{repo.dir}; git checkout #{branch}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}:master"
     ensure
       wrapper.unlink
     end
+
 
     def repo
       @repo ||= setup_repo

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -18,7 +18,7 @@ module GithubHerokuDeployer
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
       @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{branch}"
-      run "cd #{repo.dir}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}:#{branch}"
+      run "cd #{repo.dir}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
     ensure
       wrapper.unlink
     end

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -10,15 +10,16 @@ module GithubHerokuDeployer
       @id_rsa = options[:id_rsa]
       @logger = options[:logger]
       @repo_dir = options[:repo_dir]
+      @branch = ENV['APP_BRANCH_TO_DEPLOY']
     end
 
-    def push_app_to_heroku(remote="heroku", branch="master", &block)
+    def push_app_to_heroku(remote="heroku", &block)
       wrapper = ssh_wrapper
       run "cd #{repo.dir}; git remote rm #{remote}" if repo.remote(remote).url
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
-      @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{branch}"
-      run "cd #{repo.dir}; git checkout #{branch}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
+      @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{@branch}"
+      run "cd #{repo.dir}; git checkout #{@branch}; env #{wrapper.git_ssh} git push -f #{remote} #{@branch}"
     ensure
       wrapper.unlink
     end

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -18,7 +18,8 @@ module GithubHerokuDeployer
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
       @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{branch}"
-      run "cd #{repo.dir}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
+      # modified this to push non custom branch for local testing
+      run "cd #{repo.dir}; env #{wrapper.git_ssh} git checkout #{branch}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
     ensure
       wrapper.unlink
     end

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -18,7 +18,7 @@ module GithubHerokuDeployer
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
       @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{branch}"
-      run "cd #{repo.dir}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
+      run "cd #{repo.dir}; git checkout #{branch}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
     ensure
       wrapper.unlink
     end

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -18,7 +18,7 @@ module GithubHerokuDeployer
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
       @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{branch}"
-      run "cd #{repo.dir}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
+      run "cd #{repo.dir}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}:#{branch}"
     ensure
       wrapper.unlink
     end

--- a/lib/github_heroku_deployer/git.rb
+++ b/lib/github_heroku_deployer/git.rb
@@ -12,17 +12,16 @@ module GithubHerokuDeployer
       @repo_dir = options[:repo_dir]
     end
 
-    def push_app_to_heroku(remote="heroku", branch="update-gemfilelock", &block)
+    def push_app_to_heroku(remote="heroku", branch="master", &block)
       wrapper = ssh_wrapper
       run "cd #{repo.dir}; git remote rm #{remote}" if repo.remote(remote).url
       repo.add_remote(remote, @heroku_repo)
       yield(repo) if block_given?
       @logger.info "deploying #{repo.dir} to #{repo.remote(remote).url} from branch #{branch}"
-      run "cd #{repo.dir}; git checkout #{branch}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}:master"
+      run "cd #{repo.dir}; env #{wrapper.git_ssh} git push -f #{remote} #{branch}"
     ensure
       wrapper.unlink
     end
-
 
     def repo
       @repo ||= setup_repo

--- a/lib/github_heroku_deployer/heroku.rb
+++ b/lib/github_heroku_deployer/heroku.rb
@@ -12,7 +12,8 @@ module GithubHerokuDeployer
     end
 
     def heroku
-      @heroku ||= ::Heroku::API.new(api_key: @heroku_api_key)
+      #platform-api
+      @heroku ||= ::PlatformAPI.connect_oauth(@heroku_api_key)
     end
 
 
@@ -22,15 +23,17 @@ module GithubHerokuDeployer
 
     def find_or_create_app
       find_app
-    rescue ::Heroku::API::Errors::NotFound
+    rescue ::Excon::Errors::NotFound
       create_app
     end
 
     def find_app
-      heroku.get_app(@heroku_app_name)
+      #platform-api
+      heroku.app.info(@heroku_app_name)
     end
 
     def create_app
+      #platform-api
       @logger.info("Creating Heroku app with options: #{platform_api_options}")
       heroku_platform_api.organization_app.create(platform_api_options)
     end
@@ -48,11 +51,13 @@ module GithubHerokuDeployer
     end
 
     def config_set(config_vars)
-      heroku.put_config_vars(@heroku_app_name, config_vars)
+      #platform-api
+      heroku.config_var.update(@heroku_app_name, config_vars)
     end
 
     def addon_add(addon, addon_options={})
-      heroku.post_addon(@heroku_app_name, addon, addon_options)
+      #platform-api (minus addon_options support)
+      heroku.addon.create(@heroku_app_name, {plan => addon})
     end
 
     def addon_remove(addon)
@@ -60,7 +65,8 @@ module GithubHerokuDeployer
     end
 
     def post_ps_scale(process, quantity)
-      heroku.post_ps_scale(@heroku_app_name, process, quantity)
+      #platform-api
+      heroku.formation.update(@heroku_app_name, process, {"quantity" => quantity})
     end
 
     # def add_deployhooks_http(url)

--- a/lib/github_heroku_deployer/heroku.rb
+++ b/lib/github_heroku_deployer/heroku.rb
@@ -47,7 +47,13 @@ module GithubHerokuDeployer
     end
 
     def run(command)
-      heroku.post_ps(@heroku_app_name, command)
+      #platform-api
+      run_dyno = {"attach": false,
+                            "command": command,
+                            "size": "Hobby",
+                            "type": "run",
+                            "time_to_live": 1800}
+      heroku.dyno.create(@heroku_app_name, run_dyno)
     end
 
     def config_set(config_vars)
@@ -56,8 +62,8 @@ module GithubHerokuDeployer
     end
 
     def addon_add(addon, addon_options={})
-      #platform-api (minus addon_options support)
-      heroku.addon.create(@heroku_app_name, {"plan" => addon})
+      #platform-api
+      heroku.addon.create(@heroku_app_name, {"plan" => {name: addon}, "config" => addon_options})
     end
 
     def addon_remove(addon)

--- a/lib/github_heroku_deployer/heroku.rb
+++ b/lib/github_heroku_deployer/heroku.rb
@@ -57,7 +57,7 @@ module GithubHerokuDeployer
 
     def addon_add(addon, addon_options={})
       #platform-api (minus addon_options support)
-      heroku.addon.create(@heroku_app_name, {plan => addon})
+      heroku.addon.create(@heroku_app_name, {"plan" => addon})
     end
 
     def addon_remove(addon)

--- a/lib/github_heroku_deployer/heroku.rb
+++ b/lib/github_heroku_deployer/heroku.rb
@@ -48,11 +48,11 @@ module GithubHerokuDeployer
 
     def run(command)
       #platform-api
-      run_dyno = {"attach": false,
-                            "command": command,
-                            "size": "Hobby",
-                            "type": "run",
-                            "time_to_live": 1800}
+      run_dyno = {"attach"=> false,
+                            "command"=> command,
+                            "size"=> "Hobby",
+                            "type"=> "run",
+                            "time_to_live"=> 1800}
       heroku.dyno.create(@heroku_app_name, run_dyno)
     end
 

--- a/lib/github_heroku_deployer/heroku.rb
+++ b/lib/github_heroku_deployer/heroku.rb
@@ -1,4 +1,3 @@
-require "heroku-api"
 require "platform-api"
 
 module GithubHerokuDeployer
@@ -15,7 +14,6 @@ module GithubHerokuDeployer
       #platform-api
       @heroku ||= ::PlatformAPI.connect_oauth(@heroku_api_key)
     end
-
 
     def app
       @app ||= find_or_create_app
@@ -39,11 +37,13 @@ module GithubHerokuDeployer
     end
 
     def restart_app
-      heroku.post_ps_restart(@heroku_app_name)
+      #platform-api
+      heroku.dyno.restart_all(@heroku_app_name)
     end
 
     def destroy_app
-      heroku.delete_app(@heroku_app_name)
+      #platform-api
+      heroku.app.delete(@heroku_app_name)
     end
 
     def run(command)
@@ -67,7 +67,8 @@ module GithubHerokuDeployer
     end
 
     def addon_remove(addon)
-      heroku.delete_addon(@heroku_app_name, addon)
+      #platform-api
+      heroku.addon.delete(@heroku_app_name, addon)
     end
 
     def post_ps_scale(process, quantity)

--- a/lib/github_heroku_deployer/heroku.rb
+++ b/lib/github_heroku_deployer/heroku.rb
@@ -48,11 +48,11 @@ module GithubHerokuDeployer
 
     def run(command)
       #platform-api
-      run_dyno = {"attach"=> false,
-                            "command"=> command,
-                            "size"=> "Hobby",
-                            "type"=> "run",
-                            "time_to_live"=> 1800}
+      run_dyno = {attach: false,
+                            command: command,
+                            size: "Hobby",
+                            type: "run",
+                            time_to_live: 1800}
       heroku.dyno.create(@heroku_app_name, run_dyno)
     end
 

--- a/lib/github_heroku_deployer/version.rb
+++ b/lib/github_heroku_deployer/version.rb
@@ -1,3 +1,3 @@
 module GithubHerokuDeployer
-  VERSION = "0.4.2"
+  VERSION = "0.5.0-beta-1"
 end

--- a/lib/github_heroku_deployer/version.rb
+++ b/lib/github_heroku_deployer/version.rb
@@ -1,3 +1,3 @@
 module GithubHerokuDeployer
-  VERSION = "0.5.0-beta-2"
+  VERSION = "0.5.0"
 end

--- a/lib/github_heroku_deployer/version.rb
+++ b/lib/github_heroku_deployer/version.rb
@@ -1,3 +1,3 @@
 module GithubHerokuDeployer
-  VERSION = "0.5.0-beta-1"
+  VERSION = "0.5.0-beta-2"
 end

--- a/spec/lib/github_heroku_deployer/heroku_spec.rb
+++ b/spec/lib/github_heroku_deployer/heroku_spec.rb
@@ -14,12 +14,11 @@ describe GithubHerokuDeployer::Heroku do
         heroku_api_key: "asdfghjkl",
         heroku_app_name: "asdfghjkl")
       response = mock(body: 'error')
-      heroku.stub("find_app").and_raise(::Heroku::API::Errors::NotFound.new('',response))
+      heroku.stub("find_app").and_raise(::Excon::Errors::NotFound.new('',response))
 
       organization_app = double(:organization_app, create: "created")
       platform_api = double(:mock, :organization_app => organization_app)
       PlatformAPI.stub(:connect_oauth).and_return(platform_api)
-
       organization_app.should_receive(:create).with(hash_including(organization: "test-org"))
 
       heroku.find_or_create_app


### PR DESCRIPTION
**github_heroku_deployer** - uses custom branch source, will change source to master after custom branch is merged.

**g5-content-management-system** - deploys custom branch, will change to master when master can be deployed.

**g5-client-leads-service** - deploys custom branch, will change to master when master can be deployed.

Changes to push a non-master branch would not be merged to master. CMS and CLS master branches do not currently work so I needed to do that in order to audit CAC deployed apps. 